### PR TITLE
New streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ queue.add('name',{a:1})
   - return
     - an event emitter `queue`
 
-- queue.add(name,data[,delay],cb)
+- `queue.add(name,data[,delay],cb)`
   - add a new job to the queue. 
   - optional time delay
 
-- queue.has(name,cb)
+- `queue.has(name,cb)`
   - if this queue has an entry for this name
+
 - `queue.start()`
   - start a stopped queue
   - this is needed if `options.start` is not truthy or you called `queue.end` and want to continue

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ queue work to do in redis, and handle it in the same process.
 keep work safe from process restarts/crashes
 
 
+## example
+
 ```
 var todoQueue = require('todo-queue')
 
@@ -13,11 +15,129 @@ var queue = todoQueue({
   //job.name
   //job.data
 
-  // do the job here
+  console.log(job)
 
+  // all done.
   done()
 })
 
 queue.add('name',{a:1})
 
 ```
+
+
+## API
+
+
+- `queue = todoQueue(options,doJobFunction)`
+  - `options`
+    - redis
+      - default undefined. this causes redis to connet to localhost.
+      - a valid redis.createClient options object. see  https://www.npmjs.com/package/redis#rediscreateclient
+
+    - prefix||name
+      - this is the namespace of your queue.
+      - this queue uses 3 keys in redis to do its work.
+        - `prefix + ':data'` hash with the job objects. keyed by name.
+        - `prefix + ':set'` a sorted list of jobs. sorted by time inserted
+        - `prefix + ':failed'` a hash of jobs that have failed along with an error property keyed by `timstamp:jobname`
+
+    - timeout
+      - default 0
+      - the maximum time in ms a `doJobFunction` can run without calling `done`
+      - this timer is disabled by default
+
+    - retry
+      - default `3`
+      - how many times a job should be retried immediately on failure
+
+    - attempts
+      - default `5`
+      - how many times a failed job should be reinserted into the queue with a time delay from `backoff`
+
+    - backoff
+      - function (job)
+      - return number of ms to wait before trying again.
+      - defaults to `one minute * attempts * 2`
+      - this means time delays are 2,4,6,8,10 totalling 40 minutes before a job moves from data to failed.
+
+    - start
+      - default `true`
+      - if this instance should immediately start consuming the queue
+
+  - `doJobFunction(job,done)`
+    - job
+      - is an object with name and data properties 
+      - `{name: job name, data: the data you passed into add}`
+
+    - done(err)
+      - fire this callback when you are done with the job
+      - if you callback with `err` the job will be retried depending on your settings for `attempts` and `retries`
+
+  - return
+    - an event emitter `queue`
+
+- queue.add(name,data[,delay],cb)
+  - add a new job to the queue. 
+  - optional time delay
+
+- queue.has(name,cb)
+  - if this queue has an entry for this name
+- `queue.start()`
+  - start a stopped queue
+  - this is needed if `options.start` is not truthy or you called `queue.end` and want to continue
+
+- `queue.stop()`
+  - gracefully stop processing the queue.
+
+- `queue.locks(name)`
+  - when an item is being added to the queue and when an item is being processed we take out a `lock` on the name.
+  - this means calls to queue.add("name") will wait for any current processing of "name" to finish 
+  - we expose the number of locks because if events of the same name share a common resource like a file on disk it probably matters.
+
+- `queue.backoff(job)`
+  - when a job fails 
+  - the default backoff function 
+
+- `queue.countFailures(cb)`
+  - the number of items in the failed hash
+
+- `queue.getFailures(cb)`
+  - get all failures
+  - failures stick around in this redis hash forever.
+  - periodically you should clean this out and handle or log these errors
+
+- `queue.removeFailure(key,cb)`
+  - remove an item form the failed hash for this queue.
+
+- `queue.on(EVENT)`
+  - the queue is an event emitter and emits some useful metrics.
+
+  - `queue.on('metric',metric object)` 
+    - is called with one argument a metric object with a name and an optional numeric value.
+    - `{name:name,value:value}`
+    - if you use numbat-emitter style/process.emit('metric') you can pass these over after prefixing the name in a way that fits your convention.
+    - "metric"
+      - `{name: 'job', value: ms}` 
+        - time it took to process the job
+      - `{name: 'job-retry'}`
+        - when a job is being queued for time delay retry.
+      - `{name: 'job-failed'}`
+        - we have given up on this job
+      - `{name: 'redis-connected'}`
+        - redis connected
+      - `{name: 'redis-disconnected'}`
+        - redis disconnected
+      - `{name: 'redis-error'}`
+        - redis has sent a recoverable error. this is followed up by a connection attempt. 
+      - `{name: 'redis-command-error'}`
+        - redis gave an error when trying to update update/finish a job in the queue.
+  - `queue.on("idle")`
+    - this event is triggered when the queue has been drained.
+
+  - `queue.on("fail",failed job)`
+    - an job has just been marked as failed.
+
+  - `queue.on("log",log string)`
+    - some debug logs.
+

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -5,24 +5,20 @@ module.exports = lock
 function lock (locks, name, action) {
   if (!action) throw new Error('action fn required')
   if (locks[name]) {
-    console.log('LOCK: queue ', name)
     return locks[name].push(action)
   }
   locks[name] = [action]
 
-  console.log('LOCK: new ', name)
   go()
 
   function go () {
     var action = locks[name][0]
     if (!action) {
-      console.log('LOCK: done ', name)
       delete locks[name]
       return
     }
     action(once(function () {
       locks[name].shift()
-      console.log('LOCK: dequeue ', name)
       go()
     }))
   }

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -4,19 +4,25 @@ module.exports = lock
 
 function lock (locks, name, action) {
   if (!action) throw new Error('action fn required')
-  if (locks[name]) return locks[name].push(action)
+  if (locks[name]) {
+    console.log('LOCK: queue ', name)
+    return locks[name].push(action)
+  }
   locks[name] = [action]
 
+  console.log('LOCK: new ', name)
   go()
 
   function go () {
     var action = locks[name][0]
     if (!action) {
+      console.log('LOCK: done ', name)
       delete locks[name]
       return
     }
     action(once(function () {
       locks[name].shift()
+      console.log('LOCK: dequeue ', name)
       go()
     }))
   }

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,0 +1,20 @@
+// stream a range of data out of redis.
+// no data > than the current time to support time-delay retries etc
+
+module.exports = function fetch (redis, key, sequence, limit, cb) {
+  if (!limit) return setImmediate(() => cb(new Error('limit required')))
+
+  redis.zrangebyscore(key, '(' + (sequence || '-inf'), Date.now() * 10000, 'LIMIT', 0, limit, 'WITHSCORES', function (err, data) {
+    if (err) return cb(err)
+
+    var key = 0
+    var objs = []
+
+    data.forEach(function (v, i) {
+      if (!(1 & i)) key = v
+      else objs.push({seq: v, id: key})
+    })
+
+    cb(null, objs)
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,6 +1072,11 @@
         "minimist": "0.0.8"
       }
     },
+    "monotonic-timestamp": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
+      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3112,15 +3117,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3130,6 +3126,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-queue",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "standard": "^10.0.3"
   },
   "dependencies": {
+    "monotonic-timestamp": "0.0.9",
     "once": "^1.4.0",
     "redis": "^2.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-queue",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "queue work todo in redis and handle it in the same process. keep work safe from process restarts/crashes",
   "main": "index.js",
   "scripts": {

--- a/test/06-range.js
+++ b/test/06-range.js
@@ -1,0 +1,24 @@
+var test = require('tape')
+var range = require('../lib/range')
+var redis = require('redis')
+
+test('can load range', function (t) {
+  var client = redis.createClient()
+  client.del('borp')
+  var cursor = client.multi()
+  cursor.del('borp')
+  for (var i = 0; i < 20; ++i) cursor.zadd('borp', i, i + ' key')
+  cursor.exec(function () {
+    range(client, 'borp', 0, 10, function (err, data, seq) {
+      t.ok(!err, 'should not have error ' + err)
+      console.log(data)
+
+      t.equals(data.length, 10, 'should have 10 items')
+      t.equals(data[0].seq, '0', 'first should be 0')
+      t.equals(data[data.length - 1].seq, '9', 'last should be 9')
+      t.equals(data[data.length - 1].id, '9 key', 'last should have correct data')
+      client.end(true)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
this adds lots of features and changes the key names a bit in backwards compatible way.

we now support scheduling a job for some time in the future

and we now support `backoff` for failed jobs. this should help a lot for things like periodic outages where time is a factor 

we now expose if a job is locked and how many pending calls are on the lock. via `queue.locks(name)`